### PR TITLE
feat(Download Private files): Accesible private files via token

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -40,7 +40,7 @@ def handle():
 
     validate_oauth()
     validate_auth_via_api_keys()
-    validate_jwt()
+    validate_jwt(frappe.get_request_header("Authorization", None))
 
     parts = frappe.request.path[1:].split("/", 3)
     call = doctype = name = None
@@ -185,14 +185,12 @@ def validate_auth_via_api_keys():
         raise e
 
 
-def validate_jwt():
+def validate_jwt(jwt_token):
     """
         Next JWT authentication using api key and api secret
     """
     import jwt
     from newmatik.next.helpers import get_jwt_config
-
-    jwt_token = frappe.get_request_header("Authorization", None)
 
     if jwt_token and not any(x in jwt_token for x in ['token', 'Basic', 'bearer']):
         jwt_config = get_jwt_config()

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -154,6 +154,22 @@ def download_backup(path):
 
 def download_private_file(path):
 	"""Checks permissions and sends back private file"""
+
+	import jwt
+	from frappe.api import validate_jwt
+	from six.moves.urllib.parse import parse_qs
+
+	query_string = frappe.local.request.query_string
+	query = parse_qs(query_string)
+	
+	if query:
+		if query['t']:
+			try:
+				validate_jwt(query['t'][0])
+				return send_private_file(path.split("/private", 1)[1])
+			except jwt.ExpiredSignatureError as e:
+				raise Forbidden(_("You don't have permission to access this file"))
+
 	try:
 		_file = frappe.get_doc("File", {"file_url": path})
 		_file.is_downloadable()


### PR DESCRIPTION
Download private file via token as query string. "t" as the token.

sample url: ....../private/files/FB-DE-00037_Abschnitt_6.docx?t=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZWNyZXQiOiI1YjMzZmFmMjFkYzczNGEiLCJ1c2VyX2lkIjoicm9uZWwuY2FicmVyYUBuZXdtYXRpay5jb20iLCJrZXkiOiJlY2FlZmYwOGYyMGY4ZjMiLCJleHAiOjE1NTY4NTM3NzN9.EPiwB5S2hb7vIVrWrlsmqmff3n7K8pGtPzXBi5HKsVw

https://github.com/newmatik/next/issues/461