### PR TITLE
fix(timeline): Fix delete permissions

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -303,11 +303,8 @@ frappe.ui.form.Timeline = class Timeline {
 		c["delete"] = "";
 		c["edit"] = "";
 		if(c.communication_type=="Comment" && (c.comment_type || "Comment") === "Comment") {
-			if(frappe.model.can_delete("Communication")) {
-				c["delete"] = '<a class="close delete-comment" title="Delete"  href="#"><i class="octicon octicon-x"></i></a>';
-			}
-
 			if(frappe.user.name == c.sender || (frappe.user.name == 'Administrator')) {
+				c["delete"] = '<a class="close delete-comment" title="Delete"  href="#"><i class="octicon octicon-x"></i></a>';
 				c["edit"] = '<a class="edit-comment text-muted" title="Edit" href="#">Edit</a>';
 			}
 		}


### PR DESCRIPTION
Only the owner or the Administrator should be allowed to delete the Comment.

<img width="1176" alt="Screen Shot 2019-08-13 at 2 56 57 PM" src="https://user-images.githubusercontent.com/16913064/62930807-c8268a80-bdda-11e9-9051-4f5f87421f38.png">
re: https://github.com/newmatik/newmatik/issues/2122