### PR TITLE
fix(schema): Duplicate indices fix

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -265,7 +265,23 @@ class DbColumn:
 		if "decimal" in current_def['type']:
 			return self.default_changed_for_decimal(current_def)
 		else:
-			return current_def['default'] != self.default
+			cur_default = current_def['default']
+			new_default = self.default
+			if cur_default == "NULL" or cur_default is None:
+				cur_default = None
+			else:
+				# Strip quotes from default value
+				# eg. database returns default value as "'System Manager'"
+				cur_default = cur_default.lstrip("'").rstrip("'")
+
+			fieldtype = self.fieldtype
+			if fieldtype in ['Int', 'Check']:
+				cur_default = cint(cur_default)
+				new_default = cint(new_default)
+			elif fieldtype in ['Currency', 'Float', 'Percent']:
+				cur_default = flt(cur_default)
+				new_default = flt(new_default)
+			return cur_default != new_default
 
 	def default_changed_for_decimal(self, current_def):
 		try:


### PR DESCRIPTION
@creamdory We need to make this fix now, because on every migrate we are creating duplicate index and it is also slowing down the db. 
This will have no merge conflicts as well since it is new code and same as core code.

We also need to delete the duplicate indices

re: https://github.com/newmatik/newmatik/issues/2129