### PR TITLE
fix(FREEZE): List view count and list render after update

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -328,6 +328,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	render() {
+		this.render_list();
+		this.on_row_checked();
+		this.render_count();
+		this.render_tags();
+	}
+	render_list() {
 		this.$result.find('.list-row-container').remove();
 		if (this.data.length > 0) {
 			// append rows
@@ -335,9 +341,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				this.data.map(doc => this.get_list_row_html(doc)).join('')
 			);
 		}
-		this.on_row_checked();
-		this.render_count();
-		this.render_tags();
 	}
 
 	render_count() {
@@ -812,7 +815,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						// in the listview according to filters applied
 						// let's remove it manually
 						this.data = this.data.filter(d => d.name !== name);
-						this.render();
+						this.render_list();
 						return;
 					}
 
@@ -846,7 +849,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						return return_value;
 					});
 
-					this.render();
+					this.render_list();
 				});
 		});
 	}


### PR DESCRIPTION
Currently on update/insert the list view is refreshed and list count is updated. This is the main reason we are having the freeze issues, it doubles the requests.

So to fix this, the list should render when required and count should be updated after the requests are over.

PS: Already in Frappe core, so making PR just for us.