### PR TITLE
feat(home): Redirect to user module

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -1,6 +1,6 @@
 <ul class="list-unstyled sidebar-menu visible-sm visible-xs">
 	<li>
-		<a class="navbar-home" href="#">
+		<a class="navbar-home" href="/desk">
 			<img class="app-logo" src="{{ frappe.app.logo_url }}">
 		</a>
 	</li>

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -4,7 +4,7 @@
 			<a class="navbar-brand toggle-sidebar visible-xs visible-sm">
 				<i class="octicon octicon-three-bars"></i>
 			</a>
-			<a class="navbar-brand navbar-home hidden-xs hidden-sm" href="#">
+			<a class="navbar-brand navbar-home hidden-xs hidden-sm" href="/desk">
 				<img class="app-logo" src="{{ frappe.app.logo_url }}">
 			</a>
 			<ul class="nav navbar-nav" id="navbar-breadcrumbs">
@@ -17,7 +17,7 @@
 				<a class="navbar-search-button" href="#" data-toggle="modal" data-target="#search-modal"><i class="octicon octicon-search"></i></a>
 			</li>
 			<li class="dropdown dropdown-navbar-user dropdown-mobile">
-				<a class="dropdown-toggle" data-toggle="dropdown" href="#"
+				<a class="dropdown-toggle" data-toggle="dropdown" href="/desk"
 					onclick="return false;">
 				{{ avatar }}
 				<span class="ellipsis toolbar-user-fullname hidden-xs hidden-sm">


### PR DESCRIPTION
Fixed almost everywhere, from mobile view, on manually entering /desk and also from list view.

![p](https://user-images.githubusercontent.com/16913064/69778029-c7b6d180-11c8-11ea-990f-4d46c22ed5b9.gif)

re: https://github.com/newmatik/newmatik/issues/2395