### PR TITLE
fix(Email): Default gender

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -355,7 +355,7 @@ def get_contacts(email_strings):
 			contact = frappe.get_doc({
 				"doctype": "Contact",
 				"first_name": frappe.unscrub(email.split("@")[0]),
-				"gender": frappe.get_value('User', {'email':email}, 'gender')
+				"gender": frappe.get_value('User', {'email':email}, 'gender') or 'Other'
 			})
 			contact.add_email(email_id=email, is_primary=True)
 			contact.insert(ignore_permissions=True)


### PR DESCRIPTION
In case email is send to random email address which is not a user, we do not get a gender. Setting it default to 'Other'

re: https://github.com/newmatik/newmatik/issues/2413