### PR TITLE
feat(Communication): overwrite content of email on selecting email template

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -199,21 +199,8 @@ frappe.views.CommunicationComposer = Class.extend({
 				}
 				var content_field = me.dialog.fields_dict.content;
 				var subject_field = me.dialog.fields_dict.subject;
-				var content = content_field.get_value() || "";
-				var subject = subject_field.get_value() || "";
-
-				var parts = content.split('<!-- salutation-ends -->');
-
-				if(parts.length===2) {
-					content = [reply.message, "<br>", parts[1]];
-				} else {
-					content = [reply.message, "<br>", content];
-				}
-
-				content_field.set_value(content.join(''));
-
+				content_field.set_value(reply.message);
 				subject_field.set_value(reply.subject);
-
 				me.reply_added = email_template;
 			}
 


### PR DESCRIPTION
re https://github.com/newmatik/newmatik/issues/2628

referencing previous PR https://github.com/newmatik/frappe/pull/14

Overwrites the content of the email when a template is selected, as shown below:

![newmatik 2628 fix pr](https://user-images.githubusercontent.com/44422325/76401581-1295d700-63bd-11ea-8c54-e27d35d4366c.gif)
