### PR TITLE
fix(text-editor): UL fixes

### DIFF
--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -128,16 +128,3 @@
 	margin-top: 0px;
 	margin-bottom: 0px;
 }
-
-.ql-editor ol {
-	padding-left: 2.5em;
-}
-
-.ql-editor li[data-list=ordered] {
-	list-style-type: decimal;
-	padding-left: 0;
-
-	&::before {
-		content: none;
-	}
-}


### PR DESCRIPTION
padding is same now. I might appear slightly different because of list type.

<img width="245" alt="Screen Shot 2020-06-24 at 6 11 05 PM" src="https://user-images.githubusercontent.com/16913064/85558763-b0e53a00-b646-11ea-8426-26e9878509e2.png">

re: #https://github.com/newmatik/newmatik/issues/3205

Sent the PR to frappe develop. But since we are on version 12, we can fix it for ourselves as well.

PR merged in Frappe develop https://github.com/frappe/frappe/pull/10804