### PR TITLE
fix(utils.py): save comment docname to attached_to_name

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -66,8 +66,9 @@ def add_comment(reference_doctype, reference_name, content, comment_email):
 		comment_email = comment_email,
 		comment_type = 'Comment'
 	))
-	doc.content = extract_images_from_html(doc, content)
 	doc.insert(ignore_permissions = True)
+	doc.content = extract_images_from_html(doc, content)
+	doc.save(ignore_permissions=True)
 
 	follow_document(doc.reference_doctype, doc.reference_name, frappe.session.user)
 	return doc.as_dict()


### PR DESCRIPTION
Re: https://github.com/newmatik/newmatik/issues/3227

For this fix, we need to `insert` the `Comment` doctype first so that `Comment Name` will be available in the `doc` dictionary before passing it to `extract_images_from_html `. `Comment Name` is passing `None` before this PR. We also need to save the `content` field afterwards.

![comment](https://user-images.githubusercontent.com/17470909/89242588-810d5700-d634-11ea-8910-131c676d1ebb.gif)
