### PR TITLE
fix(standard.html): remove extra td width

### DIFF
--- a/frappe/templates/emails/standard.html
+++ b/frappe/templates/emails/standard.html
@@ -22,12 +22,10 @@
 						<td valign="top">
 							<table class="email-body" border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
-									<td width="15"></td>
 									<td valign="top">
 										<p>{{ content }}</p>
 										<p>{{ signature }}</p>
 									</td>
-									<td width="15"></td>
 								</tr>
 							</table>
 						</td>


### PR DESCRIPTION
Re: https://github.com/elexess/elexess/issues/1

The email template has an empty td with a set width.

![image](https://user-images.githubusercontent.com/17470909/96664028-7f764400-1384-11eb-8cc1-e04b79da2162.png)
